### PR TITLE
feat: Next.js APIエンドポイントの実装

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,6 +1,6 @@
 # =============== Base Stage ===============
 FROM node:20-alpine AS base
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl
 WORKDIR /app
 
 # =============== Dependencies Stage ===============

--- a/apps/frontend/app/api/__tests__/health.test.ts
+++ b/apps/frontend/app/api/__tests__/health.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '../health/route';
+import { NextRequest } from 'next/server';
+
+// fetchのモック
+global.fetch = vi.fn();
+
+describe('/api/health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 環境変数のモック
+    process.env.API_URL = 'http://localhost:8000';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('バックエンドAPIが正常な場合、ヘルスチェックが成功すべき', async () => {
+    // Arrange
+    const mockBackendResponse = {
+      status: 'ok',
+      database: 'connected',
+      timestamp: '2024-01-01T00:00:00.000Z',
+    };
+
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockBackendResponse),
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/health');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('ok');
+    expect(data.service).toBe('nextjs-frontend');
+    expect(data.backend.status).toBe('healthy');
+    expect(data.backend.database).toBe('connected');
+    expect(data.timestamp).toBeDefined();
+    expect(data.uptime).toBeDefined();
+  });
+
+  it('バックエンドAPIが異常な場合、ヘルスチェックが失敗すべき', async () => {
+    // Arrange
+    const mockBackendResponse = {
+      status: 'error',
+      database: 'disconnected',
+    };
+
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve(mockBackendResponse),
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/health');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    expect(response.status).toBe(503);
+    expect(data.status).toBe('error');
+    expect(data.service).toBe('nextjs-frontend');
+    expect(data.backend.status).toBe('error');
+  });
+
+  it('バックエンドAPIに接続できない場合、エラーを返すべき', async () => {
+    // Arrange
+    (fetch as jest.MockedFunction<typeof fetch>).mockRejectedValueOnce(new Error('Connection refused'));
+
+    const request = new NextRequest('http://localhost:3000/api/health');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    expect(response.status).toBe(503);
+    expect(data.status).toBe('error');
+    expect(data.service).toBe('nextjs-frontend');
+    expect(data.backend.status).toBe('error');
+    expect(data.backend.message).toBe('Connection refused');
+  });
+
+  it('API_URL環境変数が未設定の場合、デフォルトURLを使用すべき', async () => {
+    // Arrange
+    delete process.env.API_URL;
+    
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ok', database: 'connected' }),
+    });
+
+    const request = new NextRequest('http://localhost:3000/api/health');
+
+    // Act
+    await GET(request);
+
+    // Assert
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/health',
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          'Cache-Control': 'no-cache',
+        },
+      })
+    );
+  });
+});

--- a/apps/frontend/app/api/__tests__/revalidate.test.ts
+++ b/apps/frontend/app/api/__tests__/revalidate.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET, POST } from '../revalidate/route';
+import { NextRequest } from 'next/server';
+
+// Next.js関数のモック
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}));
+
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+describe('/api/revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REVALIDATE_SECRET = 'test-secret-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET /api/revalidate', () => {
+    it('APIの情報を返すべき', async () => {
+      // Arrange
+      const request = new NextRequest('http://localhost:3000/api/revalidate');
+
+      // Act
+      const response = await GET(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.service).toBe('nextjs-revalidate-api');
+      expect(data.supportedMethods).toContain('POST');
+      expect(data.requiredFields).toContain('secret');
+      expect(data.example).toBeDefined();
+      expect(data.timestamp).toBeDefined();
+    });
+  });
+
+  describe('POST /api/revalidate', () => {
+    it('有効なシークレットとパスでリバリデートが成功すべき', async () => {
+      // Arrange
+      const requestBody = {
+        path: '/test-path',
+        secret: 'test-secret-key',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.revalidated).toContain('path: /test-path');
+      expect(data.errors).toBeUndefined();
+      expect(revalidatePath).toHaveBeenCalledWith('/test-path');
+      expect(data.timestamp).toBeDefined();
+    });
+
+    it('有効なシークレットとタグでリバリデートが成功すべき', async () => {
+      // Arrange
+      const requestBody = {
+        tag: 'posts',
+        secret: 'test-secret-key',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.revalidated).toContain('tag: posts');
+      expect(data.errors).toBeUndefined();
+      expect(revalidateTag).toHaveBeenCalledWith('posts');
+      expect(data.timestamp).toBeDefined();
+    });
+
+    it('パスとタグ両方でリバリデートが成功すべき', async () => {
+      // Arrange
+      const requestBody = {
+        path: '/test-path',
+        tag: 'posts',
+        secret: 'test-secret-key',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(data.revalidated).toContain('path: /test-path');
+      expect(data.revalidated).toContain('tag: posts');
+      expect(data.errors).toBeUndefined();
+      expect(revalidatePath).toHaveBeenCalledWith('/test-path');
+      expect(revalidateTag).toHaveBeenCalledWith('posts');
+    });
+
+    it('無効なシークレットで401エラーを返すべき', async () => {
+      // Arrange
+      const requestBody = {
+        path: '/test-path',
+        secret: 'invalid-secret',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Invalid secret');
+      expect(revalidatePath).not.toHaveBeenCalled();
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('シークレットが未設定の場合401エラーを返すべき', async () => {
+      // Arrange
+      delete process.env.REVALIDATE_SECRET;
+      
+      const requestBody = {
+        path: '/test-path',
+        secret: 'any-secret',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Invalid secret');
+    });
+
+    it('パスもタグも指定されていない場合400エラーを返すべき', async () => {
+      // Arrange
+      const requestBody = {
+        secret: 'test-secret-key',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Either path or tag must be provided');
+    });
+
+    it('revalidatePathがエラーを投げた場合、エラー情報を含むべき', async () => {
+      // Arrange
+      (revalidatePath as jest.MockedFunction<typeof revalidatePath>).mockImplementationOnce(() => {
+        throw new Error('Revalidation failed');
+      });
+
+      const requestBody = {
+        path: '/test-path',
+        secret: 'test-secret-key',
+      };
+
+      const request = new NextRequest('http://localhost:3000/api/revalidate', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      });
+
+      // Act
+      const response = await POST(request);
+      const data = await response.json();
+
+      // Assert
+      expect(response.status).toBe(207); // 部分的成功
+      expect(data.errors).toContain('Failed to revalidate path /test-path: Revalidation failed');
+      expect(data.revalidated).toBeUndefined();
+    });
+  });
+});

--- a/apps/frontend/app/api/health/route.ts
+++ b/apps/frontend/app/api/health/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    // バックエンドAPIのヘルスチェック
+    const backendHealthCheck = async () => {
+      try {
+        const response = await fetch(`${process.env.API_URL || 'http://localhost:8000'}/health`, {
+          method: 'GET',
+          headers: {
+            'Cache-Control': 'no-cache',
+          },
+        });
+        
+        if (!response.ok) {
+          return { status: 'error', message: 'Backend API unhealthy' };
+        }
+        
+        const data = await response.json() as { status: string; database: string };
+        return { 
+          status: data.status === 'ok' ? 'healthy' : 'unhealthy',
+          database: data.database 
+        };
+      } catch (error) {
+        return { 
+          status: 'error', 
+          message: error instanceof Error ? error.message : 'Unknown error' 
+        };
+      }
+    };
+
+    const backendHealth = await backendHealthCheck();
+
+    // Next.js アプリケーションの基本ヘルスチェック
+    const healthData = {
+      status: backendHealth.status === 'healthy' ? 'ok' : 'error',
+      timestamp: new Date().toISOString(),
+      service: 'nextjs-frontend',
+      version: process.env.npm_package_version || '0.1.0',
+      backend: backendHealth,
+      environment: process.env.NODE_ENV || 'development',
+      uptime: process.uptime(),
+    };
+
+    // ヘルスチェック結果に応じてステータスコードを設定
+    const statusCode = healthData.status === 'ok' ? 200 : 503;
+
+    return NextResponse.json(healthData, { status: statusCode });
+  } catch (error) {
+    console.error('[Health Check Error]:', error);
+    
+    return NextResponse.json(
+      {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        service: 'nextjs-frontend',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/apps/frontend/app/api/revalidate/route.ts
+++ b/apps/frontend/app/api/revalidate/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath, revalidateTag } from 'next/cache';
+
+interface RevalidateRequest {
+  path?: string;
+  tag?: string;
+  secret?: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as RevalidateRequest;
+    const { path, tag, secret } = body;
+
+    // シークレットキーの検証
+    const revalidateSecret = process.env.REVALIDATE_SECRET;
+    if (!revalidateSecret || secret !== revalidateSecret) {
+      console.error('[Revalidate] Invalid or missing secret');
+      return NextResponse.json(
+        { error: 'Invalid secret' },
+        { status: 401 }
+      );
+    }
+
+    // パスまたはタグのいずれかが必要
+    if (!path && !tag) {
+      return NextResponse.json(
+        { error: 'Either path or tag must be provided' },
+        { status: 400 }
+      );
+    }
+
+    const results: { revalidated: string[]; errors: string[] } = {
+      revalidated: [],
+      errors: []
+    };
+
+    // パスベースのリバリデート
+    if (path) {
+      try {
+        revalidatePath(path);
+        results.revalidated.push(`path: ${path}`);
+        console.log(`[Revalidate] Successfully revalidated path: ${path}`);
+      } catch (error) {
+        const errorMessage = `Failed to revalidate path ${path}: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        results.errors.push(errorMessage);
+        console.error('[Revalidate]', errorMessage);
+      }
+    }
+
+    // タグベースのリバリデート
+    if (tag) {
+      try {
+        revalidateTag(tag);
+        results.revalidated.push(`tag: ${tag}`);
+        console.log(`[Revalidate] Successfully revalidated tag: ${tag}`);
+      } catch (error) {
+        const errorMessage = `Failed to revalidate tag ${tag}: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        results.errors.push(errorMessage);
+        console.error('[Revalidate]', errorMessage);
+      }
+    }
+
+    // レスポンス作成
+    const responseData = {
+      revalidated: results.revalidated.length > 0 ? results.revalidated : undefined,
+      errors: results.errors.length > 0 ? results.errors : undefined,
+      timestamp: new Date().toISOString(),
+    };
+
+    // エラーがある場合は部分的成功として207を返す
+    const statusCode = results.errors.length > 0 ? 207 : 200;
+
+    return NextResponse.json(responseData, { status: statusCode });
+
+  } catch (error) {
+    console.error('[Revalidate API Error]:', error);
+    
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// GET メソッドで現在のリバリデート設定情報を取得
+export async function GET() {
+  return NextResponse.json({
+    service: 'nextjs-revalidate-api',
+    version: '1.0.0',
+    supportedMethods: ['POST'],
+    requiredFields: ['secret', 'path or tag'],
+    example: {
+      path: '/features/data-fetching',
+      tag: 'posts',
+      secret: 'your-secret-key'
+    },
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary
- Next.js APIエンドポイント（/api/health、/api/revalidate）を実装
- Docker環境でのPrisma互換性問題を修正
- 全テストパス、ビルド成功を確認済み

## 実装内容

### 1. ヘルスチェックAPI（/api/health）
- ALBヘルスチェック対応のエンドポイント
- バックエンドAPI（Hono）の状態確認
- PostgreSQLデータベース接続状態の確認
- 詳細なサービス情報とアップタイムの提供

### 2. リバリデートAPI（/api/revalidate）
- Next.jsキャッシュの動的無効化
- パスベース・タグベースのリバリデーション対応
- シークレットキーによる認証機能
- バックエンドからのキャッシュ更新通知受信

### 3. Dockerfile修正
- Alpine LinuxにOpenSSLを追加
- Prismaエンジンの互換性問題を解決

## Test plan
- [x] ユニットテスト実行（36テスト全パス）
- [x] ビルド成功確認
- [x] Lint通過確認
- [x] Docker環境での動作確認
  - [x] /api/health エンドポイントの正常応答
  - [x] /api/revalidate エンドポイントの動作確認
  - [x] バックエンドAPIとの通信確認
  - [x] データベース接続確認

🤖 Generated with [Claude Code](https://claude.ai/code)